### PR TITLE
Add security analysis app skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# test
+# 보안 분석 웹 애플리케이션 예제
+
+이 저장소는 React와 Spring Boot를 활용한 Fortify SCA 연동 보안 분석 웹 애플리케이션의 기본 구조를 제공합니다.
+
+## 폴더 구조
+- `backend` : Spring Boot 기반 REST API
+- `frontend` : React SPA 프로젝트
+
+## 실행 순서
+1. MariaDB 실행 후 `application.yml`의 DB 설정을 맞춰 주세요.
+2. **백엔드**
+   ```bash
+   cd backend
+   mvn package
+   java -jar target/security-analysis-0.0.1-SNAPSHOT.jar
+   ```
+3. **프론트엔드**
+   ```bash
+   cd frontend
+   npm install
+   npm start
+   ```
+
+자세한 내용은 각 폴더의 README를 참고하세요.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,11 @@
+# 백엔드(Spring Boot)
+
+## 빌드 방법
+```bash
+mvn package
+```
+
+## 실행 방법
+```bash
+java -jar target/security-analysis-0.0.1-SNAPSHOT.jar
+```

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>${spring.boot.version}</version>
+    </parent>
+    <groupId>com.example</groupId>
+    <artifactId>security-analysis</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>Security Analysis</name>
+    <properties>
+        <java.version>21</java.version>
+        <spring.boot.version>3.2.5</spring.boot.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <version>3.3.1</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/backend/src/main/java/com/example/analysis/SecurityAnalysisApplication.java
+++ b/backend/src/main/java/com/example/analysis/SecurityAnalysisApplication.java
@@ -1,0 +1,15 @@
+package com.example.analysis;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootApplication
+@EnableAsync
+@EnableScheduling
+public class SecurityAnalysisApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(SecurityAnalysisApplication.class, args);
+    }
+}

--- a/backend/src/main/java/com/example/analysis/service/FortifyService.java
+++ b/backend/src/main/java/com/example/analysis/service/FortifyService.java
@@ -1,0 +1,14 @@
+package com.example.analysis.service;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FortifyService {
+    @Async
+    public void runScan(String projectPath) throws Exception {
+        ProcessBuilder pb = new ProcessBuilder("sourceanalyzer", "-b", "mybuild", projectPath);
+        pb.inheritIO();
+        pb.start();
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    url: jdbc:mariadb://localhost:3306/analysis
+    username: user
+    password: pass
+  jpa:
+    hibernate:
+      ddl-auto: update
+
+logging:
+  level:
+    root: INFO

--- a/frontend/.babelrc
+++ b/frontend/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
+}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,16 @@
+# 프론트엔드(React)
+
+## 설치
+```bash
+npm install
+```
+
+## 개발 서버 실행
+```bash
+npm start
+```
+
+## 빌드
+```bash
+npm run build
+```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "security-analysis-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.6.2",
+    "@mui/material": "^5.15.0",
+    "axios": "^1.5.0"
+  },
+  "scripts": {
+    "start": "webpack serve --mode development",
+    "build": "webpack --mode production"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <title>Security Analysis</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="/bundle.js"></script>
+</body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+import LoginPage from './pages/LoginPage';
+import Dashboard from './pages/Dashboard';
+import ReportPage from './pages/ReportPage';
+import SettingsPage from './pages/SettingsPage';
+
+function App() {
+  return (
+    <Routes>
+      <Route path="/" element={<LoginPage />} />
+      <Route path="/dashboard" element={<Dashboard />} />
+      <Route path="/report" element={<ReportPage />} />
+      <Route path="/settings" element={<SettingsPage />} />
+    </Routes>
+  );
+}
+
+export default App;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import App from './App';
+
+const root = createRoot(document.getElementById('root'));
+root.render(
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>
+);

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Container } from '@mui/material';
+
+export default function Dashboard() {
+  return (
+    <Container>
+      <h1>대시보드</h1>
+    </Container>
+  );
+}

--- a/frontend/src/pages/LoginPage.js
+++ b/frontend/src/pages/LoginPage.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Button, Container } from '@mui/material';
+
+export default function LoginPage() {
+  return (
+    <Container>
+      <h1>로그인</h1>
+      <Button variant="contained">로그인</Button>
+    </Container>
+  );
+}

--- a/frontend/src/pages/ReportPage.js
+++ b/frontend/src/pages/ReportPage.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Container } from '@mui/material';
+
+export default function ReportPage() {
+  return (
+    <Container>
+      <h1>분석 결과</h1>
+    </Container>
+  );
+}

--- a/frontend/src/pages/SettingsPage.js
+++ b/frontend/src/pages/SettingsPage.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Container } from '@mui/material';
+
+export default function SettingsPage() {
+  return (
+    <Container>
+      <h1>설정</h1>
+    </Container>
+  );
+}

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,0 +1,21 @@
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.js',
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist')
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        use: 'babel-loader'
+      }
+    ]
+  },
+  devServer: {
+    static: './public'
+  }
+};


### PR DESCRIPTION
## Summary
- initialize backend skeleton with Spring Boot
- add simple Fortify service with `ProcessBuilder`
- configure async and scheduling
- provide frontend React SPA skeleton with basic routing
- update README with Korean instructions

## Testing
- `mvn test` *(fails: network unreachable)*
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_6841b1352f08832783501ac1bd749a79